### PR TITLE
Add interactive getting-started notebook for Colab

### DIFF
--- a/notebooks/00_getting_started.ipynb
+++ b/notebooks/00_getting_started.ipynb
@@ -1,0 +1,183 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ELKEmxs7YP-w",
+        "outputId": "a6477dc7-a3a4-467b-da8b-4edb2d348c10"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: pytorch-dml in /usr/local/lib/python3.12/dist-packages (1.0.0)\n",
+            "Requirement already satisfied: torch>=2.0.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (2.9.0+cpu)\n",
+            "Requirement already satisfied: torchvision>=0.15.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (0.24.0+cpu)\n",
+            "Requirement already satisfied: numpy>=1.21.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (2.0.2)\n",
+            "Requirement already satisfied: tqdm>=4.65.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (4.67.1)\n",
+            "Requirement already satisfied: tensorboard>=2.13.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (2.19.0)\n",
+            "Requirement already satisfied: matplotlib>=3.5.0 in /usr/local/lib/python3.12/dist-packages (from pytorch-dml) (3.10.0)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (1.3.3)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (0.12.1)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (4.61.1)\n",
+            "Requirement already satisfied: kiwisolver>=1.3.1 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (1.4.9)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (25.0)\n",
+            "Requirement already satisfied: pillow>=8 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (11.3.0)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (3.2.5)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.12/dist-packages (from matplotlib>=3.5.0->pytorch-dml) (2.9.0.post0)\n",
+            "Requirement already satisfied: absl-py>=0.4 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (1.4.0)\n",
+            "Requirement already satisfied: grpcio>=1.48.2 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (1.76.0)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (3.10)\n",
+            "Requirement already satisfied: protobuf!=4.24.0,>=3.19.6 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (5.29.5)\n",
+            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (75.2.0)\n",
+            "Requirement already satisfied: six>1.9 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (1.17.0)\n",
+            "Requirement already satisfied: tensorboard-data-server<0.8.0,>=0.7.0 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (0.7.2)\n",
+            "Requirement already satisfied: werkzeug>=1.0.1 in /usr/local/lib/python3.12/dist-packages (from tensorboard>=2.13.0->pytorch-dml) (3.1.4)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (3.20.0)\n",
+            "Requirement already satisfied: typing-extensions>=4.10.0 in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (4.15.0)\n",
+            "Requirement already satisfied: sympy>=1.13.3 in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (1.14.0)\n",
+            "Requirement already satisfied: networkx>=2.5.1 in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (3.6.1)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (3.1.6)\n",
+            "Requirement already satisfied: fsspec>=0.8.5 in /usr/local/lib/python3.12/dist-packages (from torch>=2.0.0->pytorch-dml) (2025.3.0)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.12/dist-packages (from sympy>=1.13.3->torch>=2.0.0->pytorch-dml) (1.3.0)\n",
+            "Requirement already satisfied: markupsafe>=2.1.1 in /usr/local/lib/python3.12/dist-packages (from werkzeug>=1.0.1->tensorboard>=2.13.0->pytorch-dml) (3.0.3)\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install the library from PyPI\n",
+        "!pip install pytorch-dml"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "from pydml import DMLTrainer\n",
+        "from torchvision import models\n",
+        "\n",
+        "# Load two simple models (ResNet18)\n",
+        "# We compare two models to learn from each other\n",
+        "model_1 = models.resnet18(num_classes=10)\n",
+        "model_2 = models.resnet18(num_classes=10)\n",
+        "models_list = [model_1, model_2]\n",
+        "\n",
+        "print(\"Success: Library imported and models loaded!\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "S5oEO5tuZXfY",
+        "outputId": "7f571fb7-7c50-4489-c4e4-7fcb874c0f0a"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Success: Library imported and models loaded!\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Create Dummy Data (Fake Images) for Speed\n",
+        "# 16 images, 3 channels (RGB), 32x32 size\n",
+        "inputs = torch.randn(16, 3, 32, 32)\n",
+        "labels = torch.randint(0, 10, (16,))\n",
+        "\n",
+        "# Create a simple loader\n",
+        "train_loader = [(inputs, labels)]\n",
+        "\n",
+        "# Initialize Trainer (Using CPU for compatibility)\n",
+        "trainer = DMLTrainer(models_list, device='cpu')\n",
+        "\n",
+        "# Run Training for 1 Epoch\n",
+        "print(\"Starting training...\")\n",
+        "trainer.fit(train_loader, train_loader, epochs=1)\n",
+        "print(\"Task Completed: Training finished successfully!\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "G0ko3iwMZYna",
+        "outputId": "46d09d3d-76db-4f67-cc17-e428b04affca"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "DML Trainer initialized with 2 models\n",
+            "Config: temperature=3.0, supervised_weight=1.0, mimicry_weight=1.0\n",
+            "Starting training...\n",
+            "Starting training on cpu\n",
+            "Training 2 models collaboratively for 1 epochs\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "Epoch 1: 100%|██████████| 1/1 [00:00<00:00,  2.57it/s, loss=2.7772]\n",
+            "Evaluating: 100%|██████████| 1/1 [00:00<00:00, 12.59it/s]"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Epoch 1/1 - 0.48s\n",
+            "  Train Loss: 2.7772 | Train Acc: 15.62%\n",
+            "  Val Loss: 2.2474 | Val Acc: 21.88%\n",
+            "  Model 0: Train Acc: 12.50% | Val Acc: 25.00%\n",
+            "  Model 1: Train Acc: 18.75% | Val Acc: 18.75%\n",
+            "Task Completed: Training finished successfully!\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "N4kUdP6BZiNN"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Added notebooks/00_getting_started.ipynb as requested in Issue #6. I used a synthetic dataset to ensure the notebook runs instantly (< 1 min) on Google Colab, fulfilling the speed requirement.