### PR TITLE
Added VGG11/13/16/19 models for CIFAR datasets :boom: 

### DIFF
--- a/examples/vgg_demo.py
+++ b/examples/vgg_demo.py
@@ -1,0 +1,162 @@
+"""
+VGG Models for CIFAR Demo
+
+This example demonstrates how to use VGG architectures (VGG11, VGG13, VGG16, VGG19)
+with the PyTorch-DML library for CIFAR datasets.
+
+VGG models are deep convolutional networks that use very small (3x3) convolution filters.
+This implementation is adapted for CIFAR's 32x32 images.
+"""
+
+import torch
+import torch.nn as nn
+from pydml.models.cifar import vgg11, vgg13, vgg16, vgg19
+from pydml.trainers import DMLTrainer
+
+
+def demonstrate_vgg_models():
+    """Demonstrate VGG model creation and usage."""
+    print("=" * 80)
+    print("VGG MODELS FOR CIFAR DEMONSTRATION")
+    print("=" * 80)
+    print()
+    
+    # 1. Create different VGG variants
+    print("1. Creating VGG Models")
+    print("-" * 80)
+    
+    models_info = [
+        ("VGG-11", vgg11(num_classes=10)),
+        ("VGG-13", vgg13(num_classes=10)),
+        ("VGG-16", vgg16(num_classes=10)),
+        ("VGG-19", vgg19(num_classes=10)),
+    ]
+    
+    for name, model in models_info:
+        num_params = sum(p.numel() for p in model.parameters())
+        print(f"{name:8} - Parameters: {num_params:,}")
+    
+    print()
+    
+    # 2. Test with sample input
+    print("2. Testing Forward Pass")
+    print("-" * 80)
+    
+    # Create sample CIFAR batch
+    batch_size = 4
+    x = torch.randn(batch_size, 3, 32, 32)
+    print(f"Input shape: {x.shape}")
+    
+    # Test VGG16
+    model = vgg16(num_classes=10)
+    model.eval()
+    
+    with torch.no_grad():
+        output = model(x)
+    
+    print(f"Output shape: {output.shape}")
+    print(f"Predictions (logits):\n{output[0]}")
+    print()
+    
+    # 3. Deep Mutual Learning with VGG models
+    print("3. Deep Mutual Learning with Mixed VGG Models")
+    print("-" * 80)
+    
+    # Create ensemble of different VGG variants
+    dml_models = [
+        vgg11(num_classes=10),
+        vgg13(num_classes=10),
+        vgg16(num_classes=10),
+    ]
+    
+    print(f"Created ensemble with {len(dml_models)} VGG variants:")
+    for i, model in enumerate(dml_models):
+        num_params = sum(p.numel() for p in model.parameters())
+        print(f"  Model {i+1}: {num_params:,} parameters")
+    
+    # Initialize DML trainer
+    trainer = DMLTrainer(
+        models=dml_models,
+        device='cpu'
+    )
+    
+    print(f"\n✓ DML Trainer initialized with {len(dml_models)} models")
+    print()
+    
+    # 4. VGG for CIFAR-100
+    print("4. VGG for CIFAR-100 (100 classes)")
+    print("-" * 80)
+    
+    model_cifar100 = vgg16(num_classes=100)
+    x_cifar100 = torch.randn(4, 3, 32, 32)
+    
+    model_cifar100.eval()
+    with torch.no_grad():
+        output_cifar100 = model_cifar100(x_cifar100)
+    
+    print(f"Input shape: {x_cifar100.shape}")
+    print(f"Output shape: {output_cifar100.shape}")
+    print(f"✓ Successfully created VGG16 for CIFAR-100")
+    print()
+    
+    # 5. Batch Normalization comparison
+    print("5. Batch Normalization Comparison")
+    print("-" * 80)
+    
+    model_with_bn = vgg16(num_classes=10, batch_norm=True)
+    model_without_bn = vgg16(num_classes=10, batch_norm=False)
+    
+    params_with_bn = sum(p.numel() for p in model_with_bn.parameters())
+    params_without_bn = sum(p.numel() for p in model_without_bn.parameters())
+    
+    print(f"VGG16 with BatchNorm:    {params_with_bn:,} parameters")
+    print(f"VGG16 without BatchNorm: {params_without_bn:,} parameters")
+    print(f"Difference: {params_with_bn - params_without_bn:,} parameters")
+    print()
+    
+    # 6. Model architecture summary
+    print("6. VGG16 Architecture Summary")
+    print("-" * 80)
+    
+    model = vgg16(num_classes=10)
+    
+    # Count layers
+    conv_layers = sum(1 for m in model.modules() if isinstance(m, nn.Conv2d))
+    fc_layers = sum(1 for m in model.modules() if isinstance(m, nn.Linear))
+    bn_layers = sum(1 for m in model.modules() if isinstance(m, nn.BatchNorm2d))
+    
+    print(f"Convolutional layers: {conv_layers}")
+    print(f"Fully connected layers: {fc_layers}")
+    print(f"Batch normalization layers: {bn_layers}")
+    print()
+    
+    # 7. Memory footprint
+    print("7. Memory Footprint Comparison")
+    print("-" * 80)
+    
+    for name, model in [("VGG-11", vgg11()), ("VGG-16", vgg16()), ("VGG-19", vgg19())]:
+        # Estimate memory (parameters only)
+        param_size = sum(p.numel() * p.element_size() for p in model.parameters())
+        param_size_mb = param_size / (1024 ** 2)
+        print(f"{name:8} - Model size: {param_size_mb:.2f} MB")
+    
+    print()
+    print("=" * 80)
+    print("DEMONSTRATION COMPLETE")
+    print("=" * 80)
+    print()
+    print("Key Features:")
+    print("  ✓ VGG11, VGG13, VGG16, VGG19 available")
+    print("  ✓ Adapted for CIFAR-10/100 (32x32 images)")
+    print("  ✓ Supports both CIFAR-10 and CIFAR-100")
+    print("  ✓ Optional batch normalization")
+    print("  ✓ Compatible with DML training")
+    print()
+    print("Next Steps:")
+    print("  1. Import: from pydml.models.cifar import vgg16")
+    print("  2. Create: model = vgg16(num_classes=10)")
+    print("  3. Train with DML or standard training")
+
+
+if __name__ == '__main__':
+    demonstrate_vgg_models()

--- a/pydml/models/cifar/__init__.py
+++ b/pydml/models/cifar/__init__.py
@@ -3,5 +3,11 @@
 from pydml.models.cifar.resnet import resnet32, resnet110
 from pydml.models.cifar.mobilenet import mobilenet_v2
 from pydml.models.cifar.wrn import wrn_28_10
+from pydml.models.cifar.vgg import vgg11, vgg13, vgg16, vgg19
 
-__all__ = ["resnet32", "resnet110", "mobilenet_v2", "wrn_28_10"]
+__all__ = [
+    "resnet32", "resnet110", 
+    "mobilenet_v2", 
+    "wrn_28_10",
+    "vgg11", "vgg13", "vgg16", "vgg19"
+]

--- a/pydml/models/cifar/vgg.py
+++ b/pydml/models/cifar/vgg.py
@@ -1,0 +1,178 @@
+"""
+VGG for CIFAR datasets.
+
+Adapted from the VGG paper for CIFAR-10/100 (32x32 images).
+Reference: "Very Deep Convolutional Networks for Large-Scale Image Recognition"
+Paper: https://arxiv.org/abs/1409.1556
+"""
+
+import torch
+import torch.nn as nn
+
+
+class VGG(nn.Module):
+    """
+    VGG network adapted for CIFAR datasets.
+    
+    Modified from the original VGG for 32x32 images instead of 224x224.
+    Uses smaller feature maps and fewer pooling layers to maintain
+    spatial resolution for small images.
+    
+    Args:
+        vgg_name: VGG variant ('VGG11', 'VGG13', 'VGG16', 'VGG19')
+        num_classes: Number of output classes (10 for CIFAR-10, 100 for CIFAR-100)
+        batch_norm: Whether to use batch normalization (default: True)
+    """
+    
+    def __init__(self, vgg_name, num_classes=10, batch_norm=True):
+        super(VGG, self).__init__()
+        self.batch_norm = batch_norm
+        self.features = self._make_layers(cfg[vgg_name])
+        
+        # Classifier adapted for CIFAR (32x32 -> after 5 pools: 1x1)
+        self.classifier = nn.Sequential(
+            nn.Linear(512, 512),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Linear(512, 512),
+            nn.ReLU(True),
+            nn.Dropout(),
+            nn.Linear(512, num_classes),
+        )
+        
+        self._initialize_weights()
+    
+    def forward(self, x):
+        out = self.features(x)
+        out = out.view(out.size(0), -1)
+        out = self.classifier(out)
+        return out
+    
+    def _make_layers(self, cfg):
+        layers = []
+        in_channels = 3
+        for x in cfg:
+            if x == 'M':
+                layers += [nn.MaxPool2d(kernel_size=2, stride=2)]
+            else:
+                if self.batch_norm:
+                    layers += [
+                        nn.Conv2d(in_channels, x, kernel_size=3, padding=1),
+                        nn.BatchNorm2d(x),
+                        nn.ReLU(inplace=True)
+                    ]
+                else:
+                    layers += [
+                        nn.Conv2d(in_channels, x, kernel_size=3, padding=1),
+                        nn.ReLU(inplace=True)
+                    ]
+                in_channels = x
+        return nn.Sequential(*layers)
+    
+    def _initialize_weights(self):
+        """Initialize weights using Kaiming initialization."""
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.constant_(m.bias, 0)
+
+
+# VGG configurations
+# Numbers represent output channels, 'M' represents max pooling
+cfg = {
+    'VGG11': [64, 'M', 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'VGG13': [64, 64, 'M', 128, 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M'],
+    'VGG16': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 'M', 512, 512, 512, 'M', 512, 512, 512, 'M'],
+    'VGG19': [64, 64, 'M', 128, 128, 'M', 256, 256, 256, 256, 'M', 512, 512, 512, 512, 'M', 512, 512, 512, 512, 'M'],
+}
+
+
+def vgg11(num_classes=10, batch_norm=True):
+    """
+    VGG-11 model for CIFAR datasets.
+    
+    Args:
+        num_classes: Number of output classes (default: 10)
+        batch_norm: Use batch normalization (default: True)
+    
+    Returns:
+        VGG11 model instance
+    
+    Example:
+        >>> from pydml.models.cifar import vgg11
+        >>> model = vgg11(num_classes=100)  # For CIFAR-100
+        >>> x = torch.randn(4, 3, 32, 32)
+        >>> y = model(x)
+        >>> print(y.shape)  # torch.Size([4, 100])
+    """
+    return VGG('VGG11', num_classes=num_classes, batch_norm=batch_norm)
+
+
+def vgg13(num_classes=10, batch_norm=True):
+    """
+    VGG-13 model for CIFAR datasets.
+    
+    Args:
+        num_classes: Number of output classes (default: 10)
+        batch_norm: Use batch normalization (default: True)
+    
+    Returns:
+        VGG13 model instance
+    
+    Example:
+        >>> from pydml.models.cifar import vgg13
+        >>> model = vgg13(num_classes=100)  # For CIFAR-100
+        >>> x = torch.randn(4, 3, 32, 32)
+        >>> y = model(x)
+        >>> print(y.shape)  # torch.Size([4, 100])
+    """
+    return VGG('VGG13', num_classes=num_classes, batch_norm=batch_norm)
+
+
+def vgg16(num_classes=10, batch_norm=True):
+    """
+    VGG-16 model for CIFAR datasets.
+    
+    Args:
+        num_classes: Number of output classes (default: 10)
+        batch_norm: Use batch normalization (default: True)
+    
+    Returns:
+        VGG16 model instance
+    
+    Example:
+        >>> from pydml.models.cifar import vgg16
+        >>> model = vgg16(num_classes=10)  # For CIFAR-10
+        >>> x = torch.randn(4, 3, 32, 32)
+        >>> y = model(x)
+        >>> print(y.shape)  # torch.Size([4, 10])
+    """
+    return VGG('VGG16', num_classes=num_classes, batch_norm=batch_norm)
+
+
+def vgg19(num_classes=10, batch_norm=True):
+    """
+    VGG-19 model for CIFAR datasets.
+    
+    Args:
+        num_classes: Number of output classes (default: 10)
+        batch_norm: Use batch normalization (default: True)
+    
+    Returns:
+        VGG19 model instance
+    
+    Example:
+        >>> from pydml.models.cifar import vgg19
+        >>> model = vgg19(num_classes=100)  # For CIFAR-100
+        >>> x = torch.randn(4, 3, 32, 32)
+        >>> y = model(x)
+        >>> print(y.shape)  # torch.Size([4, 100])
+    """
+    return VGG('VGG19', num_classes=num_classes, batch_norm=batch_norm)

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for VGG models.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from pydml.models.cifar import vgg11, vgg13, vgg16, vgg19
+
+
+class TestVGGModels:
+    """Test suite for VGG models."""
+    
+    def test_vgg11_creation(self):
+        """Test VGG11 model creation."""
+        model = vgg11(num_classes=10)
+        assert isinstance(model, nn.Module)
+        
+        # Count parameters
+        num_params = sum(p.numel() for p in model.parameters())
+        assert num_params > 0
+    
+    def test_vgg13_creation(self):
+        """Test VGG13 model creation."""
+        model = vgg13(num_classes=10)
+        assert isinstance(model, nn.Module)
+    
+    def test_vgg16_creation(self):
+        """Test VGG16 model creation."""
+        model = vgg16(num_classes=10)
+        assert isinstance(model, nn.Module)
+    
+    def test_vgg19_creation(self):
+        """Test VGG19 model creation."""
+        model = vgg19(num_classes=10)
+        assert isinstance(model, nn.Module)
+    
+    def test_vgg11_forward_pass(self):
+        """Test VGG11 forward pass with CIFAR-sized input."""
+        model = vgg11(num_classes=10)
+        model.eval()
+        
+        # CIFAR input size: [batch, 3, 32, 32]
+        x = torch.randn(4, 3, 32, 32)
+        
+        with torch.no_grad():
+            output = model(x)
+        
+        # Output should be [batch, num_classes]
+        assert output.shape == (4, 10)
+    
+    def test_vgg16_forward_pass(self):
+        """Test VGG16 forward pass with CIFAR-sized input."""
+        model = vgg16(num_classes=10)
+        model.eval()
+        
+        x = torch.randn(2, 3, 32, 32)
+        
+        with torch.no_grad():
+            output = model(x)
+        
+        assert output.shape == (2, 10)
+    
+    def test_vgg19_forward_pass(self):
+        """Test VGG19 forward pass with CIFAR-sized input."""
+        model = vgg19(num_classes=10)
+        model.eval()
+        
+        x = torch.randn(8, 3, 32, 32)
+        
+        with torch.no_grad():
+            output = model(x)
+        
+        assert output.shape == (8, 10)
+    
+    def test_vgg_cifar100(self):
+        """Test VGG models with CIFAR-100 (100 classes)."""
+        model = vgg16(num_classes=100)
+        model.eval()
+        
+        x = torch.randn(4, 3, 32, 32)
+        
+        with torch.no_grad():
+            output = model(x)
+        
+        assert output.shape == (4, 100)
+    
+    def test_vgg_batch_norm(self):
+        """Test VGG with and without batch normalization."""
+        # With batch norm (default)
+        model_bn = vgg16(num_classes=10, batch_norm=True)
+        has_bn = any(isinstance(m, nn.BatchNorm2d) for m in model_bn.modules())
+        assert has_bn, "Model should contain BatchNorm layers"
+        
+        # Without batch norm
+        model_no_bn = vgg16(num_classes=10, batch_norm=False)
+        has_bn = any(isinstance(m, nn.BatchNorm2d) for m in model_no_bn.modules())
+        assert not has_bn, "Model should not contain BatchNorm layers"
+    
+    def test_vgg_gradient_flow(self):
+        """Test that gradients flow through VGG model."""
+        model = vgg16(num_classes=10)
+        model.train()
+        
+        x = torch.randn(2, 3, 32, 32, requires_grad=True)
+        output = model(x)
+        
+        # Compute loss and backward
+        loss = output.sum()
+        loss.backward()
+        
+        # Check that input has gradients
+        assert x.grad is not None
+        assert x.grad.shape == x.shape
+    
+    def test_vgg_parameter_count(self):
+        """Test that parameter counts are reasonable."""
+        models_info = [
+            (vgg11, 'VGG11'),
+            (vgg13, 'VGG13'),
+            (vgg16, 'VGG16'),
+            (vgg19, 'VGG19'),
+        ]
+        
+        param_counts = []
+        for model_fn, name in models_info:
+            model = model_fn(num_classes=10)
+            num_params = sum(p.numel() for p in model.parameters())
+            param_counts.append((name, num_params))
+            print(f"{name}: {num_params:,} parameters")
+        
+        # VGG19 should have more parameters than VGG11
+        assert param_counts[3][1] > param_counts[0][1]
+    
+    def test_vgg_different_batch_sizes(self):
+        """Test VGG with different batch sizes."""
+        model = vgg16(num_classes=10)
+        model.eval()
+        
+        batch_sizes = [1, 2, 4, 8, 16, 32]
+        
+        for batch_size in batch_sizes:
+            x = torch.randn(batch_size, 3, 32, 32)
+            with torch.no_grad():
+                output = model(x)
+            assert output.shape == (batch_size, 10)
+    
+    def test_vgg_training_mode(self):
+        """Test switching between train and eval modes."""
+        model = vgg16(num_classes=10)
+        
+        # Training mode
+        model.train()
+        assert model.training
+        
+        # Eval mode
+        model.eval()
+        assert not model.training
+    
+    def test_vgg_reproducibility(self):
+        """Test that VGG produces consistent outputs with same seed."""
+        torch.manual_seed(42)
+        model = vgg16(num_classes=10)
+        x = torch.randn(2, 3, 32, 32)
+        
+        model.eval()
+        with torch.no_grad():
+            output1 = model(x)
+        
+        # Reset and test again
+        model.eval()
+        with torch.no_grad():
+            output2 = model(x)
+        
+        # Outputs should be identical
+        assert torch.allclose(output1, output2)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Description
Implements VGG architecture variants (VGG11, VGG13, VGG16, VGG19) adapted for CIFAR datasets.

## Changes
- ✅ Adds VGG models implementation 
- ✅ Support for CIFAR-10 and CIFAR-100 
- ✅ Optional batch normalization (enabled by default)
- ✅ Proper weight initialization (Kaiming)
- ✅ comprehensive tests 
- ✅ Demo script
- ✅ Compatible with DML training

## Usage

```python
from pydml.models.cifar import vgg16

model = vgg16(num_classes=10)
```

Closes #3